### PR TITLE
#61 query_id optimization and control

### DIFF
--- a/src/main/java/cc/blynk/clickhouse/ClickHouseUtil.java
+++ b/src/main/java/cc/blynk/clickhouse/ClickHouseUtil.java
@@ -1,5 +1,8 @@
 package cc.blynk.clickhouse;
 
+import java.security.SecureRandom;
+import java.util.Base64;
+
 public final class ClickHouseUtil {
 
     private ClickHouseUtil() {
@@ -68,6 +71,17 @@ public final class ClickHouseUtil {
         }
         String escaped = escape(s);
         return '`' + escaped + '`';
+    }
+
+    //threadsafe
+    private static final SecureRandom secureRandom = new SecureRandom();
+    //threadsafe
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder();
+
+    public static String generateQueryId() {
+        byte[] randomBytes = new byte[16];
+        secureRandom.nextBytes(randomBytes);
+        return base64Encoder.encodeToString(randomBytes);
     }
 
 }

--- a/src/main/java/cc/blynk/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/cc/blynk/clickhouse/settings/ClickHouseProperties.java
@@ -91,7 +91,7 @@ public class ClickHouseProperties {
     private Long maxInsertBlockSize;
     private Boolean insertDeduplicate;
     private Boolean insertDistributedSync;
-
+    private boolean enableQueryId;
 
     public ClickHouseProperties() {
         this(new Properties());
@@ -159,6 +159,7 @@ public class ClickHouseProperties {
         this.maxInsertBlockSize = getSetting(info, ClickHouseQueryParam.MAX_INSERT_BLOCK_SIZE);
         this.insertDeduplicate = getSetting(info, ClickHouseQueryParam.INSERT_DEDUPLICATE);
         this.insertDistributedSync = getSetting(info, ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC);
+        this.enableQueryId = getSetting(info, ClickHouseQueryParam.ENABLE_QUERY_ID);
     }
 
     public Properties asProperties() {
@@ -224,6 +225,7 @@ public class ClickHouseProperties {
         ret.put(ClickHouseQueryParam.MAX_INSERT_BLOCK_SIZE.getKey(), maxInsertBlockSize);
         ret.put(ClickHouseQueryParam.INSERT_DEDUPLICATE.getKey(), insertDeduplicate);
         ret.put(ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC.getKey(), insertDistributedSync);
+        ret.put(ClickHouseQueryParam.ENABLE_QUERY_ID.getKey(), enableQueryId);
 
         return ret.getProperties();
     }
@@ -289,6 +291,7 @@ public class ClickHouseProperties {
         setMaxInsertBlockSize(properties.maxInsertBlockSize);
         setInsertDeduplicate(properties.insertDeduplicate);
         setInsertDistributedSync(properties.insertDistributedSync);
+        setEnableQueryId(properties.enableQueryId);
     }
 
     public Map<ClickHouseQueryParam, String> buildQueryParams(boolean ignoreDatabase) {
@@ -393,7 +396,7 @@ public class ClickHouseProperties {
         }
 
         if (sessionId != null) {
-            params.put(ClickHouseQueryParam.SESSION_ID, String.valueOf(sessionId));
+            params.put(ClickHouseQueryParam.SESSION_ID, sessionId);
         }
 
         if (sessionTimeout != null) {
@@ -945,6 +948,14 @@ public class ClickHouseProperties {
 
     public void setInsertDistributedSync(Boolean insertDistributedSync) {
         this.insertDistributedSync = insertDistributedSync;
+    }
+
+    public boolean isEnableQueryId() {
+        return enableQueryId;
+    }
+
+    public void setEnableQueryId(boolean enableQueryId) {
+        this.enableQueryId = enableQueryId;
     }
 
     public ClickHouseProperties merge(ClickHouseProperties second) {

--- a/src/main/java/cc/blynk/clickhouse/settings/ClickHouseQueryParam.java
+++ b/src/main/java/cc/blynk/clickhouse/settings/ClickHouseQueryParam.java
@@ -322,6 +322,7 @@ public enum ClickHouseQueryParam {
                 "How to calculate TOTALS when HAVING is present, as well as when "
                         + "max_rows_to_group_by and group_by_overflow_mode = 'any' are present."),
 
+    ENABLE_QUERY_ID("enable_query_id", false, Boolean.class, ""),
     QUERY_ID("query_id", null, String.class, ""),
 
     QUEUE_MAX_WAIT_MS("queue_max_wait_ms", null, Integer.class, ""),


### PR DESCRIPTION
`QueryId` now turned off by default. Should be explicitly enabled if necessary.
Also optimized the speed to queryId generation and made the length of id 10 chars less while randomness is increased.