### PR TITLE
add relocations to shade to avoid jar conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,18 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>cc.blynk.clickhouse.org.slf4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jpountz</pattern>
+                                    <shadedPattern>cc.blynk.clickhouse.net.jpountz</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
currently, the lz4 and slf4j are packaged in the release jar, but sometimes class conflict happens.
It's better to relocate the lz4 and slf4j import to avoid class conflict.