### PR TITLE
Change ClickHouse Docker repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 services:
   - docker
 before_script:
-  - docker run -e TZ=Europe/Moscow -d -p 127.0.0.1:8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:latest
+  - docker run -e TZ=Europe/Moscow -d -p 127.0.0.1:8123:8123 --name some-clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:latest
 
 cache:
   directories:


### PR DESCRIPTION
New versions are located in clickhouse/clickhouse-server only.